### PR TITLE
Reset form validity when the data model changes

### DIFF
--- a/xtForm.js
+++ b/xtForm.js
@@ -59,6 +59,8 @@
     }, function(valid) {
       if (ngModel.$dirty) {
         self.showErrors();
+      } else {
+        self.resetValidity();
       }
     }, true);
   }


### PR DESCRIPTION
Validity of the form is not refreshed if the form data model is changed
programmatically (eg. with a reset button). This minor change refreshes the validation on programmatic model change.
