### PR TITLE
Added support for radio buttons group validation

### DIFF
--- a/xtForm.js
+++ b/xtForm.js
@@ -110,6 +110,16 @@
       if (ngModel.$error.messages !== undefined) {
         errors += ngModel.$error.messages;
       }
+      
+      // if the element is a radio button, set the tooltip on the element that is declared on the (data-val-cont) on the radio button
+      if (this.element[0].nodeName == 'INPUT' && this.element[0].type == 'radio') {
+
+         if (this.element[0].attributes['data-val-cont'] == undefined)
+             throw new Error("You must define (data-val-cont) on the radio button element, so xtForm sets the xt-error css class and the tooltip on.");
+
+         var contId = this.element[0].attributes['data-val-cont'].value;
+         this.element = $("#" + contId);
+      }
 
       this.element.addClass('xt-error');
 


### PR DESCRIPTION
Validates radio buttons group, and puts the (.xt-error) class and the tooltip on the element that is declared on the (data-val-cont="containerId") of the radio element.

In addition, the code throws an error if the developer forgets to add the (data-val-cont) attribute.

![radio_button_group_validation](https://cloud.githubusercontent.com/assets/2285974/3843323/4fe46956-1e3f-11e4-8c62-c18de7897893.png)
