### PR TITLE
Use object property bracket notation around Javascript keywords to fix I...

### DIFF
--- a/component/inline/validationInline.dir.js
+++ b/component/inline/validationInline.dir.js
@@ -17,7 +17,7 @@ xtForm.directive('xtValidationInline', function ($templateCache) {
         },
         link: function (scope, element, attrs) {
 
-            var inputId = attrs.for || attrs.xtValidationInline;
+            var inputId = attrs['for'] || attrs.xtValidationInline;
             if (angular.isUndefined(inputId)) {
                 throw new Error('The validation input id must be specified eg. for="id"');
             }

--- a/component/inline/validationInline.test.js
+++ b/component/inline/validationInline.test.js
@@ -43,7 +43,7 @@ describe('inline validation directive', function () {
             expect(function () {
                 var tmp = '<form xt-form><xt-validation-inline for="el1"></xt-validation-inline></form>';
                 setTemplate(tmp);
-            }).toThrow(new Error('Can not find the input element for the validation directive'));
+            }).toThrow(new Error('Can not find input element for the validation directive'));
         });
 
         it('should add xt-validation-inline class to element', function () {

--- a/component/tooltip/validationTooltip.js
+++ b/component/tooltip/validationTooltip.js
@@ -48,7 +48,7 @@ xtForm.directive('xtValidationTooltip', function ($timeout) {
             function setupNgModel() {
 
                 // allow for a different tooltip container that is not on the ngModel element
-                var ngModelElementId = attrs.for || attrs.xtValidationTooltip;
+                var ngModelElementId = attrs['for'] || attrs.xtValidationTooltip;
                 ngModelElement = ngModelElementId ?
                     angular.element(document.getElementById(ngModelElementId)) :
                     element;

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -4,7 +4,7 @@ module.exports = function (config) {
         basePath: './',
 
         files: [
-            'bower_components/jquery/jquery.js',
+            'bower_components/jquery/dist/jquery.js',
             'bower_components/angular/angular.js',
             'bower_components/angular-mocks/angular-mocks.js',
             'component/**/*.module.js',


### PR DESCRIPTION
...E8 compatibility issues. This simple fix was all that was needed to get xtform working in IE8 for a site that I work on

Fixes #20
